### PR TITLE
General improvements and fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: Ruby
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.0
+      - name: Setup cache key and directory for gems cache
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-v2-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-v2
+      - name: Bundle install
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3 --without production
+      - name: RSpec
+        run: bundle exec rake spec
+      - name: Rubocop
+        run: bundle exec rake rubocop
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Style/StringLiterals:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-rspec
+
 AllCops:
   TargetRubyVersion: 2.7
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,14 +3,31 @@ require:
 
 AllCops:
   TargetRubyVersion: 2.7
-
+  NewCops: enable
+Layout/LineLength:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Metrics/BlockLength:
+  Enabled: false
+Metrics/ClassLength:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Metrics/ParameterLists:
+  Max: 10
+RSpec/ContextWording:
+  Enabled: false
+RSpec/ExampleLength:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes
-
 Style/StringLiteralsInInterpolation:
   Enabled: true
   EnforcedStyle: double_quotes
 
-Layout/LineLength:
-  Max: 120

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,4 @@ gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 
 gem "rubocop", "~> 1.21"
+gem "rubocop-rspec", "~> 2.11.1"

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ gem "rake", "~> 13.0"
 
 gem "rspec", "~> 3.0"
 
-gem "rubocop", "~> 1.21"
-gem "rubocop-rspec", "~> 2.11.1"
+gem "rubocop", "~> 1.48.1"
+gem "rubocop-rspec", "~> 2.19.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.17.0)
       parser (>= 3.1.1.0)
+    rubocop-rspec (2.11.1)
+      rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
     unicode-display_width (2.1.0)
 
@@ -50,6 +52,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)
+  rubocop-rspec (~> 2.11.1)
 
 BUNDLED WITH
    2.3.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
     unicode-display_width (2.1.0)
 
 PLATFORMS
-  arm64-darwin-21
+  ruby
 
 DEPENDENCIES
   app_rail-steps!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,12 +8,13 @@ GEM
   specs:
     ast (2.4.2)
     diff-lcs (1.5.0)
+    json (2.6.3)
     parallel (1.22.1)
-    parser (3.1.2.0)
+    parser (3.2.1.1)
       ast (~> 2.4.1)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.3.0)
+    regexp_parser (2.7.0)
     rexml (3.2.5)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
@@ -28,21 +29,25 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    rubocop (1.27.0)
+    rubocop (1.48.1)
+      json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.16.0, < 2.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.26.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.17.0)
-      parser (>= 3.1.1.0)
-    rubocop-rspec (2.11.1)
-      rubocop (~> 1.19)
-    ruby-progressbar (1.11.0)
-    unicode-display_width (2.1.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.27.0)
+      parser (>= 3.2.1.0)
+    rubocop-capybara (2.17.1)
+      rubocop (~> 1.41)
+    rubocop-rspec (2.19.0)
+      rubocop (~> 1.33)
+      rubocop-capybara (~> 2.17)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.4.2)
 
 PLATFORMS
   ruby
@@ -51,8 +56,8 @@ DEPENDENCIES
   app_rail-steps!
   rake (~> 13.0)
   rspec (~> 3.0)
-  rubocop (~> 1.21)
-  rubocop-rspec (~> 2.11.1)
+  rubocop (~> 1.48.1)
+  rubocop-rspec (~> 2.19.0)
 
 BUNDLED WITH
    2.3.5

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Or install it yourself as:
 require 'app_rail/steps'
 
 ...
-#inside your module/class include the displayable modile
+#inside your module/class include the displayable module
 include AppRail::Steps::Displayable
 
 ...

--- a/app_rail-steps.gemspec
+++ b/app_rail-steps.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/spec/app_rail/steps/background_location/region_spec.rb
+++ b/spec/app_rail/steps/background_location/region_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe AppRail::Steps::BackgroundLocation::Region do
+  subject { test_struct.new(id) }
+
   let(:test_struct) { Struct.new(:id) { include AppRail::Steps::Displayable } }
   let(:test_class) { Class.new { include AppRail::Steps::Displayable } }
   let(:id) { 1 }
 
-  subject { test_struct.new(id) }
   describe "#region" do
     context "required" do
       let(:result) { subject.ar_background_location_region(id: "home", latitude: 51.2, longitude: -0.5) }

--- a/spec/app_rail/steps/charts/dashboard_spec.rb
+++ b/spec/app_rail/steps/charts/dashboard_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe AppRail::Steps::Charts::Dashboard do
+  subject { test_struct.new(id) }
+
   let(:test_struct) { Struct.new(:id) { include AppRail::Steps::Displayable } }
   let(:test_class) { Class.new { include AppRail::Steps::Displayable } }
   let(:id) { 1 }
 
-  subject { test_struct.new(id) }
   describe "#ar_charts_dashboard_statistic" do
     context "required" do
       let(:result) { subject.ar_charts_dashboard_statistic(id: 1, title: "London", text: "10,000,000") }

--- a/spec/app_rail/steps/core/list_spec.rb
+++ b/spec/app_rail/steps/core/list_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe AppRail::Steps::Core::List do
+  subject { test_struct.new(id) }
+
   let(:test_struct) { Struct.new(:id) { include AppRail::Steps::Displayable } }
   let(:test_class) { Class.new { include AppRail::Steps::Displayable } }
   let(:id) { 1 }
-
-  subject { test_struct.new(id) }
 
   describe "#ar_core_list_item" do
     context "text" do

--- a/spec/app_rail/steps/core/stack_spec.rb
+++ b/spec/app_rail/steps/core/stack_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe AppRail::Steps::Core::Stack do
+  subject { test_struct.new(id) }
+
   let(:test_struct) { Struct.new(:id) { include AppRail::Steps::Displayable } }
   let(:test_class) { Class.new { include AppRail::Steps::Displayable } }
   let(:id) { 1 }
 
-  subject { test_struct.new(id) }
   describe "#ar_core_stack_text" do
     context "text and label" do
       let(:result) { subject.ar_core_stack_text(text: "London", label: "City") }

--- a/spec/app_rail/steps/core/stack_spec.rb
+++ b/spec/app_rail/steps/core/stack_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe AppRail::Steps::Core::Stack do
       it { expect(result[:text]).to eq "London" }
       it { expect(result[:sfSymbolName]).to eq "map" }
       it { expect(result[:materialIconName]).to eq "map" }
-      it { expect(result[:label]).to eq nil }
+      it { expect(result[:label]).to be_nil }
     end
   end
 

--- a/spec/app_rail/steps/core_forms/form_spec.rb
+++ b/spec/app_rail/steps/core_forms/form_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe AppRail::Steps::CoreForms::Form do
     it { expect(result[:label]).to eq "Challenge Type" }
     it { expect(result[:multiple_selection_options]).to eq multiple_section_options }
     it { expect(result[:selection_type]).to eq :single }
-    it { expect(result[:optional]).to eq false }
-    it { expect(result[:show_other_option]).to eq false }
+    it { expect(result[:optional]).to be false }
+    it { expect(result[:show_other_option]).to be false }
   end
 
   describe "#ar_core_forms_form_multiple_selection_options" do
@@ -41,7 +41,7 @@ RSpec.describe AppRail::Steps::CoreForms::Form do
 
     it { expect(result[:text]).to eq "Open for all" }
     it { expect(result[:hint]).to eq "Every user will be able to join" }
-    it { expect(result[:isPreSelected]).to eq false }
+    it { expect(result[:isPreSelected]).to be false }
   end
 
   describe "#ar_core_forms_form_number" do
@@ -54,7 +54,7 @@ RSpec.describe AppRail::Steps::CoreForms::Form do
     it { expect(result[:number_type]).to eq :number }
     it { expect(result[:label]).to eq "Target Amount" }
     it { expect(result[:placeholder]).to eq "100 Eur" }
-    it { expect(result[:optional]).to eq false }
+    it { expect(result[:optional]).to be false }
     it { expect(result[:default_text_answer]).to eq 50 }
   end
 
@@ -68,8 +68,8 @@ RSpec.describe AppRail::Steps::CoreForms::Form do
     it { expect(result[:item_type]).to eq :text }
     it { expect(result[:label]).to eq "Your Location" }
     it { expect(result[:placeholder]).to eq "London" }
-    it { expect(result[:optional]).to eq false }
-    it { expect(result[:multiline]).to eq false }
+    it { expect(result[:optional]).to be false }
+    it { expect(result[:multiline]).to be false }
     it { expect(result[:hint]).to eq "Maximum 20 characters" }
   end
 
@@ -80,7 +80,7 @@ RSpec.describe AppRail::Steps::CoreForms::Form do
     it { expect(result[:item_type]).to eq :date }
     it { expect(result[:date_type]).to eq :calendar }
     it { expect(result[:label]).to eq "Start Date" }
-    it { expect(result[:optional]).to eq true }
+    it { expect(result[:optional]).to be true }
   end
 
   describe "#ar_core_forms_form_time" do
@@ -89,7 +89,7 @@ RSpec.describe AppRail::Steps::CoreForms::Form do
     it { expect(result[:id]).to eq 1 }
     it { expect(result[:item_type]).to eq :time }
     it { expect(result[:label]).to eq "Start Time" }
-    it { expect(result[:optional]).to eq true }
+    it { expect(result[:optional]).to be true }
   end
 
   describe "#ar_core_forms_form_email" do
@@ -102,7 +102,7 @@ RSpec.describe AppRail::Steps::CoreForms::Form do
     it { expect(result[:item_type]).to eq :email }
     it { expect(result[:label]).to eq "Your Email" }
     it { expect(result[:placeholder]).to eq "example@email.com" }
-    it { expect(result[:optional]).to eq false }
+    it { expect(result[:optional]).to be false }
     it { expect(result[:default_text_answer]).to eq "montse@futureworkshops.com" }
   end
 
@@ -116,7 +116,7 @@ RSpec.describe AppRail::Steps::CoreForms::Form do
     it { expect(result[:item_type]).to eq :secure }
     it { expect(result[:label]).to eq "Your Password" }
     it { expect(result[:placeholder]).to eq "Secret123" }
-    it { expect(result[:optional]).to eq false }
+    it { expect(result[:optional]).to be false }
     it { expect(result[:hint]).to eq "Must be at least 8 characters long" }
   end
 end

--- a/spec/app_rail/steps/core_forms/form_spec.rb
+++ b/spec/app_rail/steps/core_forms/form_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe AppRail::Steps::CoreForms::Form do
+  subject { test_struct.new(id) }
+
   let(:test_struct) { Struct.new(:id) { include AppRail::Steps::Displayable } }
   let(:test_class) { Class.new { include AppRail::Steps::Displayable } }
   let(:id) { 1 }
 
-  subject { test_struct.new(id) }
   describe "#ar_core_forms_form_section" do
     let(:result) { subject.ar_core_forms_form_section(label: "Personal Information", id: 1) }
 
@@ -84,6 +85,7 @@ RSpec.describe AppRail::Steps::CoreForms::Form do
 
   describe "#ar_core_forms_form_time" do
     let(:result) { subject.ar_core_forms_form_time(label: "Start Time", id: 1, optional: true) }
+
     it { expect(result[:id]).to eq 1 }
     it { expect(result[:item_type]).to eq :time }
     it { expect(result[:label]).to eq "Start Time" }

--- a/spec/app_rail/steps/core_forms/question_spec.rb
+++ b/spec/app_rail/steps/core_forms/question_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe AppRail::Steps::CoreForms::Question do
     it { expect(result[:label]).to eq "Challenge Type" }
     it { expect(result[:multiple_selection_options]).to eq multiple_section_options }
     it { expect(result[:selection_type]).to eq :single }
-    it { expect(result[:optional]).to eq false }
-    it { expect(result[:show_other_option]).to eq false }
+    it { expect(result[:optional]).to be false }
+    it { expect(result[:show_other_option]).to be false }
   end
 end

--- a/spec/app_rail/steps/core_forms/question_spec.rb
+++ b/spec/app_rail/steps/core_forms/question_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe AppRail::Steps::CoreForms::Question do
+  subject { test_struct.new(id) }
+
   let(:test_struct) { Struct.new(:id) { include AppRail::Steps::Displayable } }
   let(:test_class) { Class.new { include AppRail::Steps::Displayable } }
   let(:id) { 1 }
 
-  subject { test_struct.new(id) }
   describe "#ar_core_forms_form_multiple_selection" do
     let(:multiple_section_options) do
       [{ text: "Alcohol Free", isPreSelected: true }, { text: "Sunrise Yoga", isPreSelected: false }]

--- a/spec/app_rail/steps/grid/grid_spec.rb
+++ b/spec/app_rail/steps/grid/grid_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe AppRail::Steps::Grid::Grid do
+  subject { test_struct.new(id) }
+
   let(:test_struct) { Struct.new(:id) { include AppRail::Steps::Displayable } }
   let(:test_class) { Class.new { include AppRail::Steps::Displayable } }
   let(:id) { 1 }
 
-  subject { test_struct.new(id) }
   describe "#ar_styled_content_grid_large_section" do
     let(:result) { subject.ar_styled_content_grid_large_section(id: 0, text: "Mountains") }
 

--- a/spec/app_rail/steps/maps/confirm_location_spec.rb
+++ b/spec/app_rail/steps/maps/confirm_location_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe AppRail::Steps::Maps::ConfirmLocation do
+  subject { test_struct.new(id) }
+
   let(:test_struct) { Struct.new(:id) { include AppRail::Steps::Displayable } }
   let(:test_class) { Class.new { include AppRail::Steps::Displayable } }
   let(:id) { 1 }
 
-  subject { test_struct.new(id) }
   describe "#ar_maps_map_item" do
     context "text" do
       let(:result) { subject.ar_maps_confirm_location(text: "London", latitude: 51.5, longitude: 0.51) }

--- a/spec/app_rail/steps/maps/map_spec.rb
+++ b/spec/app_rail/steps/maps/map_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe AppRail::Steps::Maps::Map do
+  subject { test_struct.new(id) }
+
   let(:test_struct) { Struct.new(:id) { include AppRail::Steps::Displayable } }
   let(:test_class) { Class.new { include AppRail::Steps::Displayable } }
   let(:id) { 1 }
 
-  subject { test_struct.new(id) }
   describe "#ar_maps_map_item" do
     context "text" do
       let(:result) { subject.ar_maps_map_item(text: "London", latitude: 51.5, longitude: 0.51) }

--- a/spec/app_rail/steps_spec.rb
+++ b/spec/app_rail/steps_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe AppRail::Steps do
   it "has a version number" do
-    expect(AppRail::Steps::VERSION).not_to be nil
+    expect(AppRail::Steps::VERSION).not_to be_nil
   end
 end


### PR DESCRIPTION
- Add Github Actions workflow to run `rspec` and `rubocop`
- Fix `Gemfile.lock` platforms
- Fix typo
- Add `rubocop-rspec` gem
- Fix `rubocop` offenses
- Upgrade `rubocop` gem
- Disable some `rubocop` rules